### PR TITLE
sp_make.mk script naming error correction

### DIFF
--- a/meta-sunplus/recipes-core/images/files/sp_make.mk
+++ b/meta-sunplus/recipes-core/images/files/sp_make.mk
@@ -19,7 +19,7 @@ F_UBT=u-boot.img-a7021_ppg2
 F_DTB=sp7021-ltpp3g2revD.dtb
 
 #F_ROO=img-spt-tppg2.squashfs
-F_ROO=img-sp-tinl-tppg2.ext4
+F_ROO=img-sp-tiny-tppg2.ext4
 
 all: ${D0}/${OUTD}/ISPBOOOT.BIN
 


### PR DESCRIPTION
The 22. line of sp_make.mk has 
F_ROO=img-sp-tinl-tppg2.ext4

And the make -f sp_make.mk  does not create ISPBOOOT.BIN file because of this error.
I think this is a typo error and changed to ;
F_ROO=img-sp-tiny-tppg2.ext4